### PR TITLE
Reuse shared workflows to run tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -3,29 +3,5 @@ name: Run Tests
 on: [push, pull_request]
 
 jobs:
-  runtests:
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/quattor/quattor-test-container:latest
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
-    - name: Determine hash for caching key
-      id: cachekeystep
-      run: echo "pomcachekey=${{ hashFiles('**/pom.xml') }}" >> $GITHUB_ENV
-    - name: Cache Maven packages
-      uses: actions/cache@v4
-      with:
-        path: /tmp/m2
-        key: ${{ runner.os }}-m2-${{ env.pomcachekey }}
-        restore-keys: ${{ runner.os }}-m2-
-    - name: run tests
-      run: |
-        # make sure it exists before chown
-        mkdir -p /tmp/m2
-        chown -R quattortest:quattortest . /tmp/m2
-        # we have to run as a non-root user to pass the spma tests
-        # secondly, we first download all maven dependencies and then run the tests because it fails with hanging downloads otherwise.
-        runuser --shell /bin/bash --preserve-environment --command "source /usr/bin/mvn_test.sh && mvn_run \"dependency:resolve-plugins dependency:go-offline $MVN_ARGS\" && mvn_test" quattortest
-      env:
-        MVN_ARGS: -Dmaven.repo.local=/tmp/m2
+  standard-maven:
+    uses: quattor/release/.github/workflows/maven-tests.yaml@main


### PR DESCRIPTION
Move to defining workflows in the release repository and reusing them rather than trying to keep the workflows up-to-date and in sync with each other across all repos.